### PR TITLE
Fix some accessibility issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -618,7 +618,7 @@ h2 {
   margin-bottom: 30px;
   max-width: 884px; }
 
-h3 {
+h3, h2.small {
   font-size: 20px;
   font-weight: 600;
   line-height: 34px; }

--- a/css/style.css
+++ b/css/style.css
@@ -858,12 +858,10 @@ body.landing .button:hover {
   line-height: 15px;
   padding:10px 15px;
 }
-#guide hr {
-  background:#ccc;
-  height:1px;
-  display: block;
-  border:0px;
-  margin:5px 0px;
+#guide li.border {
+  border-top: 1px solid #C2C2C2;
+  margin-top:5px;
+  padding-top:12px;
 }
 
 #guide code {

--- a/download.html
+++ b/download.html
@@ -4,7 +4,7 @@
   <title>cabal - downloads</title>
 
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
 	<meta name="description" content="p2p chat" />
 

--- a/download.html
+++ b/download.html
@@ -46,7 +46,7 @@
 
   </div></div></header>
 
-  <div class="content">
+  <main class="content">
     <div class="wrapper">
 
     <section class="light"><div class="section-wrapper">
@@ -88,6 +88,8 @@
             <img src="cli.png" alt="cli app" width="600px"/>
         </div>
     </div>
+
+  </div></main>
 
 <script>
   window.addEventListener("load", function(e) {

--- a/download.html
+++ b/download.html
@@ -31,7 +31,7 @@
 
     <div id='overlay'></div>
 
-    <a class="nav-logo" href="/"></a>
+    <a class="nav-logo" href="/" aria-label="home"></a>
 
     <div class="nav-right">
       <div class="nav-links">

--- a/faq.html
+++ b/faq.html
@@ -5,7 +5,7 @@
     <title>cabal // faq</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
     <meta name="description" content="p2p chat" />
 

--- a/faq.html
+++ b/faq.html
@@ -44,7 +44,7 @@
       </div>
     </header>
 
-    <div class="content">
+    <main class="content">
       <div class="wrapper">
         <section class="light">
           <div class="section-wrapper">
@@ -87,7 +87,7 @@
           </div>
         </section>
       </div>
-    </div>
+    </main>
 
     <script>
       window.addEventListener("load", function(e) {

--- a/faq.html
+++ b/faq.html
@@ -29,7 +29,7 @@
         <div class="inner-wrapper">
           <nav id="navBar" class="no-js nav-bar">
             <div id='overlay'></div>
-            <a class="nav-logo" href="/"></a>
+            <a class="nav-logo" href="/" aria-label="home"></a>
             <div class="nav-right">
               <div class="nav-links">
                 <ul>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>cabal</title>
 
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
 	<meta name="description" content="p2p chat" />
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
     <div id='overlay'></div>
 
-  <a class="nav-logo" href="/"></a>
+  <a class="nav-logo" href="/" aria-label="home"></a>
 
 
     <div class="nav-right">

--- a/index.html
+++ b/index.html
@@ -62,10 +62,8 @@
         <li><b>Desktop:</b> <a href="https://github.com/cabal-club/cabal-desktop/releases">cabal-desktop</a></li>
         <li><b>Terminal:</b> <code><a href="https://nodejs.org">npm</a> install --global cabal</code></li>
         <li><b>Source Code:</b> <a href='https://github.com/cabal-club'>git</a></li>
-        <hr/>
-        <li><b>FAQ:</b> <a href="faq.html">Frequently Asked Questions</a></li>
-        <hr/>
-        <li><b>IRC:</b> <a href='https://kiwi.freenode.net/#cabal.club'>irc://irc.freenode.net/#cabal.club</a></li>
+        <li class="border"><b>FAQ:</b> <a href="faq.html">Frequently Asked Questions</a></li>
+        <li class="border"><b>IRC:</b> <a href='https://kiwi.freenode.net/#cabal.club'>irc://irc.freenode.net/#cabal.club</a></li>
       </ul>
   </div></div></section>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
   <section class="light"><div class="section-wrapper"><div class="columns">
     <div>
       <h1>cabal</h1>
-      <h3>experimental p2p community<br />chat platform</h3>
+      <h2 class="small">experimental p2p community<br />chat platform</h2>
     </div>
     <div>
       <ul id='guide'>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 
   </div></div></header>
 
-  <div class="content">
+  <main class="content">
     <div class="wrapper">
 
   <section class="light"><div class="section-wrapper"><div class="columns">
@@ -95,6 +95,8 @@
       <img src="desktop.png" alt="desktop app" width="600px"/>
     </div>
   </div></div></section>
+
+  </div></main>
 
 <script>
   window.addEventListener("load", function(e) {


### PR DESCRIPTION
This patch addresses some accessibility issues on the site:

- The logo link now has discernible text. Previously, a screen reader user wouldn't know what this link was for or why they should/should not click it.
- The "guide" list would break/confuse screen readers, as it contained non-`<li>` children. Screen readers have a special way of announcing lists, but only do so for _valid lists_.
- The _experimental p2p community_ heading jumped from an `<h1>` to an `<h3>`, which can be confusing.
- The pages were missing a `<main>` content area.
- Scaling and zooming was disabled. This prevents people from zooming in to better read text.

Each issue has been addressed in its own commit for ease of review. Let me know if there's anything I can do to help get this merged!